### PR TITLE
Adding support for rgba color code in tracks

### DIFF
--- a/app/models/track.py
+++ b/app/models/track.py
@@ -39,8 +39,13 @@ class Track(db.Model):
 
     @property
     def font_color(self):
-        h = self.color.lstrip('#')
-        a = 1 - (0.299 * int(h[0:2], 16) + 0.587 * int(h[2:4], 16) + 0.114 * int(h[4:6], 16))/255
+        if self.color.startswith('#'):
+            h = self.color.lstrip('#')
+            a = 1 - (0.299 * int(h[0:2], 16) + 0.587 * int(h[2:4], 16) + 0.114 * int(h[4:6], 16))/255
+        elif self.color.startswith('rgba'):
+            h = self.color.lstrip('rgba').replace('(', '', 1).replace(')', '', 1)
+            h = h.split(',')
+            a = 1 - (0.299 * int(int(h[0]), 16) + 0.587 * int(int(h[1]), 16) + 0.114 * int(int(h[2]), 16)) / 255
         return '#000000' if (a < 0.5) else '#ffffff'
 
     @property


### PR DESCRIPTION
Fixes #4508 

#### Short description of what this resolves:

Previously when a color for a track was selected from the slider, it was giving an error due to the absence of the code to handle the `rgba` color code format

#### Changes proposed in this pull request:

- Updated `app/models/track.py` to accept `rgba` color code format.


